### PR TITLE
Update dockerfile to use multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ WORKDIR /parkertron
 
 RUN apk add --no-cache --update git curl lua-stdlib lua musl-dev g++ libc-dev tesseract-ocr tesseract-ocr-dev \
  && go mod tidy \
- && go build
+ && go build -o parkertron
 
-CMD ["/go/src/parkertron/parkertron"]
+FROM alpine:latest
+WORKDIR /root/
+RUN apk add --no-cache --update git curl lua-stdlib lua musl-dev g++ libc-dev tesseract-ocr tesseract-ocr-dev
+COPY --from=0 /parkertron/parkertron .
+CMD ["./parkertron"]


### PR DESCRIPTION
This pr adjusts the docker file to use multistage builds as covered in https://docs.docker.com/develop/develop-images/multistage-build/ Based on initial comparisons done using https://docs.docker.com/develop/develop-images/multistage-build/ it appears to reduce the size from around 1GB to around ~300-400MB. This number can be further reduced by doing things such as stripping debug symbols on the binary https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/ and removing any dependencies from the second image that were only required for builds.