### PR TITLE
resolve issue with file names being too long

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -26,6 +26,10 @@ func parseImage(remoteURL string) (imageText string, err error) {
 	lastBin := strings.LastIndex(remoteURL, "/")
 	fileName := strings.Split(remoteURL[lastBin+1:], "?")[0]
 
+	if len(fileName) > 150 {
+		fileName = fileName[len(fileName)-50:]
+	}
+
 	Log.Debug("Filename is " + fileName)
 
 	//open a file for writing


### PR DESCRIPTION
This resolves an issue I have noticed when the name of a file is too long due to discord renaming it.